### PR TITLE
Update to v3 and update get method in bill model

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,13 @@ Get a bill:
 
 ```ruby
 bill = Billplz::Bill.new({ bill_id: 'abc123'})
-bill.get
+bill = bill.get
+
+# state (due, overdue and paid)
+bill['state']
+
+# paid (return false for due and overdue bill; true for paid bill)
+bill['paid']
 ```
 
 Delete a bill:

--- a/lib/billplz/bill.rb
+++ b/lib/billplz/bill.rb
@@ -1,6 +1,6 @@
 module Billplz
   class Bill < Model
-    self.api_url = 'https://www.billplz.com/api/v2/bills'
+    self.api_url = 'https://www.billplz.com/api/v3/bills'
 
     def create
       requires!(@payload, :collection_id, :email, :name, :amount, :callback_url)
@@ -11,6 +11,7 @@ module Billplz
       requires!(@payload, :bill_id)
       @api_url = "#{@api_url}/#{@payload[:bill_id]}"
       request(:get, nil)
+      JSON.parse(@response.body) if success?
     end
 
     def delete

--- a/lib/billplz/collection.rb
+++ b/lib/billplz/collection.rb
@@ -1,6 +1,6 @@
 module Billplz
   class Collection < Model
-    self.api_url = 'https://www.billplz.com/api/v2/collections'
+    self.api_url = 'https://www.billplz.com/api/v3/collections'
 
     def create
       requires!(@payload, :title)


### PR DESCRIPTION
billplz won't support api v2 after 31/10/2016. 
In the [api v3]( (https://billplz-staging.herokuapp.com/api#create-a-bill)) , bill model is allowed to access `state` and `paid`. Hence, `@response` should be passed in `JSON` format to enable the user to access the attributes. 